### PR TITLE
DEV-2304 Use exact reason of OSError

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,16 +81,16 @@ def handle_event(event: Event):
 
         outcome = EventOutcome.SUCCESS
         data["message"] = f"The bag '{basename}' unzipped in '{extract_path}'"
+        log.info(data["message"])
     except BadZipFile:
         outcome = EventOutcome.FAIL
         data["message"] = f"{filename} is not a a valid zipfile."
-        log.warning(f"{filename} is not a a valid zipfile.")
+        log.warning(data["message"])
     except OSError as e:
         outcome = EventOutcome.FAIL
         data["message"] = f"Error when unzipping: {str(e)}"
-        log.warning(f"Error when unzipping: {str(e)}")
+        log.warning(data["message"])
 
-    log.info(data["message"])
     send_event(data, outcome, event.correlation_id)
 
 

--- a/main.py
+++ b/main.py
@@ -85,10 +85,10 @@ def handle_event(event: Event):
         outcome = EventOutcome.FAIL
         data["message"] = f"{filename} is not a a valid zipfile."
         log.warning(f"{filename} is not a a valid zipfile.")
-    except OSError:
+    except OSError as e:
         outcome = EventOutcome.FAIL
         data["message"] = f"{filename} does not exit."
-        log.warning(f"{filename} does not exit.")
+        log.warning(f"Error when unzipping: {str(e)}")
 
     log.info(data["message"])
     send_event(data, outcome, event.correlation_id)

--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ def handle_event(event: Event):
         log.warning(f"{filename} is not a a valid zipfile.")
     except OSError as e:
         outcome = EventOutcome.FAIL
-        data["message"] = f"{filename} does not exit."
+        data["message"] = f"Error when unzipping: {str(e)}"
         log.warning(f"Error when unzipping: {str(e)}")
 
     log.info(data["message"])


### PR DESCRIPTION
When an OSError is raised, a warning is logged and a failed event with the same logstring as message is produced. That reason was hardcoded stating that the file could not be found. However an OSError can also be raised for different reasons.

Change it to the actual reason of the OSError, for both logging and the message in event.